### PR TITLE
Fix mobile menu toggle visibility

### DIFF
--- a/index-fixed.html
+++ b/index-fixed.html
@@ -18,13 +18,13 @@
 <body>
   <script>document.documentElement.classList.remove('no-js');</script>
 
+<button class="th-burger" aria-label="Avaa valikko" aria-controls="th-mobile-menu" aria-expanded="false">
+  <span></span>
+  <span></span>
+  <span></span>
+</button>
 <header class="th-header">
   <div class="th-header__inner">
-    <button class="th-burger" aria-label="Avaa valikko" aria-controls="th-mobile-menu" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
     <a class="th-brand" href="#">
       <span class="th-brand__mark">TH</span>
       <span class="th-brand__name">Lapin ikkuna</span>


### PR DESCRIPTION
## Summary
- Ensure the mobile menu button sits outside the header to escape its stacking context so it remains visible when the menu overlay is open

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68987c7fff108322ba9b8ab78c8e30a5