### PR TITLE
Improve responsive layout and mobile usability

### DIFF
--- a/index-fixed.html
+++ b/index-fixed.html
@@ -18,7 +18,7 @@
 <body>
   <script>document.documentElement.classList.remove('no-js');</script>
 
-<button class="th-burger" aria-label="Avaa valikko" aria-controls="th-mobile-menu" aria-expanded="false">
+<button class="th-burger" type="button" aria-label="Avaa valikko" aria-controls="th-mobile-menu" aria-expanded="false">
   <span></span>
   <span></span>
   <span></span>
@@ -226,19 +226,19 @@
     </div>
     <div class="footer-contact">
   <h4>Yhteystiedot</h4>
-  <p>
+  <a href="tel:+358401234567">
     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#2c7be5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.18 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.12.81.3 1.6.54 2.35a2 2 0 0 1-.45 2.11l-1.27 1.27a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.75.24 1.54.42 2.35.54A2 2 0 0 1 22 16.92z"/>
     </svg>
     040 123 4567
-  </p>
-  <p>
+  </a>
+  <a href="mailto:info@lapinikkuna.fi">
     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#4caf50" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M4 4h16v16H4z" stroke="none"/>
       <polyline points="4 4 12 13 20 4"/>
     </svg>
     info@lapinikkuna.fi
-  </p>
+  </a>
   <p>
     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#f5b301" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M21 10c0 6-9 12-9 12S3 16 3 10a9 9 0 1 1 18 0z"/>

--- a/style-fixed-purge.css
+++ b/style-fixed-purge.css
@@ -16,6 +16,12 @@ body{
   overflow-x: hidden;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
 /* Yhteinen ambient-kerros */
 body::before,
 body::after {
@@ -48,7 +54,7 @@ body::after { transform: translate3d(0, calc(var(--bg-shift, 0) * -1), 0); }
 /* Container */
 .container {
   width: 100%;
-  max-width: 100%; /* ei kiinteää pikselirajaa */
+  max-width: 1440px;
   margin: 0 auto;
   padding-left: var(--side-margin);
   padding-right: var(--side-margin);
@@ -70,6 +76,7 @@ a.cta {
   text-decoration: none;
   box-shadow: 0 6px 20px rgba(33, 103, 255, 0.35);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  min-height: 44px;
 }
 button.cta:hover,
 a.cta:hover {
@@ -90,6 +97,7 @@ a.nav-cta {
   text-decoration: none;
   box-shadow: 0 6px 20px rgba(33, 103, 255, 0.35);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  min-height: 44px;
 }
 button.cta:hover,
 a.cta:hover {
@@ -113,6 +121,7 @@ a.cta-2 {
     0 8px 20px rgba(163, 230, 163, 0.35),
     inset 0 1px rgba(255,255,255,0.4);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+  min-height: 44px;
 }
 
 button.cta-2:hover,
@@ -211,14 +220,18 @@ header img {
   margin-top: 32px;
 }
 
-/* Mobiili – pinotaan päällekkäin */
-@media (max-width: 768px) {
+/* Mobiili ja tabletit – pinotaan päällekkäin */
+@media (max-width: 1024px) {
   .hero .container {
     flex-direction: column;
+    text-align: center;
   }
   .hero-text,
   .hero-image {
     flex: 1 1 100%;
+  }
+  .hero-image {
+    margin-top: 2rem;
   }
 }
 .services {
@@ -1059,16 +1072,28 @@ a.cta-2.cta-big {
   opacity: 1;
   transform: translateY(0);
 }
-.footer-contact p {
+.footer-contact p,
+.footer-contact a {
   display: flex;
   align-items: center;
   line-height: 1.5; /* lisää pystysuunnan tilaa */
   overflow: visible; /* varmistaa ettei ikonit leikkaannu */
+  padding: 8px 0;
+}
+
+.footer-contact a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer-contact a:hover {
+  text-decoration: underline;
 }
 .footer-contact h4,
 .footer-links h4,
 .footer-brand .tagline,
 .footer-contact p,
+.footer-contact a,
 .footer-links a {
   color: rgba(20, 20, 20, 0.85);
 }
@@ -1084,7 +1109,8 @@ a.cta-2.cta-big {
   overflow: visible;
 }
 
-.footer-contact p:hover svg {
+.footer-contact p:hover svg,
+.footer-contact a:hover svg {
   stroke: #2c7be5; /* yhtenäinen brändisininen hoverissa */
   filter: drop-shadow(0 0 4px rgba(44,123,229,0.6));
   transform: scale(1.1);
@@ -1408,7 +1434,7 @@ a.cta-2.cta-big {
   text-decoration: none;
   color: var(--color-black);
   font-weight: 500;
-  padding: 4px 0;
+  padding: 8px 0;
   transition: color 0.3s ease;
 }
 .th-nav__link::after {
@@ -1436,6 +1462,7 @@ a.cta-2.cta-big {
   box-shadow: 0 6px 20px rgba(33, 103, 255, 0.35), inset 0 1px rgba(255,255,255,0.3);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
   backdrop-filter: blur(2px);
+  min-height: 44px;
 }
 .th-btn:hover {
   transform: translateY(-2px) scale(1.03);

--- a/var-fixed-purge.css
+++ b/var-fixed-purge.css
@@ -36,3 +36,31 @@
 
   --nav-gap: 2.22vw;
 }
+
+@media (max-width: 1024px) {
+  :root {
+    --font-size-hero: 48px;
+    --line-height-hero: 56px;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --font-size-hero: 36px;
+    --line-height-hero: 44px;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --font-size-hero: 30px;
+    --line-height-hero: 38px;
+  }
+}
+
+@media (max-width: 320px) {
+  :root {
+    --font-size-hero: 26px;
+    --line-height-hero: 32px;
+  }
+}


### PR DESCRIPTION
## Summary
- stack hero layout on tablets and phones and adjust typography with CSS variables for 1024/768/480/320 widths
- enlarge tap targets and make buttons/links easier to interact with
- make contact details clickable and constrain container width for large screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898824f32888322bc0210fcce55b642