### PR TITLE
Improve accessibility

### DIFF
--- a/index-fixed.html
+++ b/index-fixed.html
@@ -40,7 +40,7 @@
     <a class="th-btn" href="#yhteys">Ota yhteyttä</a>
   </div>
 </header>
-<nav id="th-mobile-menu" class="th-mobile-menu" hidden>
+<nav id="th-mobile-menu" class="th-mobile-menu" hidden aria-label="Mobiilivalikko">
   <ul>
     <li><a href="#palvelut">Palvelut</a></li>
     <li><a href="#referenssit">Referenssit</a></li>
@@ -60,7 +60,7 @@
       </div>
     </div>
     <div class="hero-image">
-      <img src="kuvat/ikkunapesu.png" alt="Ikkunanpesu">
+      <img src="kuvat/ikkunapesu.png" alt="Henkilö pesee ikkunaa">
     </div>
   </div>
   <div class="hero-gloss"></div> <!-- kiiltoefekti -->
@@ -71,17 +71,17 @@
   <h2 class="section-title"><span>Mitä palveluihimme kuuluu</span></h2>
   <div class="cards">
     <div class="card">
-      <img src="kuvat/koti-icon.png" alt="Koti-ikoni">
+      <img src="kuvat/koti-icon.png" alt="Kuvake talosta">
       <h3 class="gradient-title">Kotiisi</h3>
       <p>Puhdasta näkymää varten – tulemme sovittuna aikana ja jätämme ikkunasi säihkymään.</p>
     </div>
     <div class="card">
-      <img src="kuvat/yritys-icon.png" alt="Yritys-ikoni">
+      <img src="kuvat/yritys-icon.png" alt="Kuvake toimistorakennuksesta">
       <h3 class="gradient-title">Yrityksellesi</h3>
       <p>Siistit ikkunat antavat hyvän ensivaikutelman – huolehdimme toimitilojesi kirkkaudesta.</p>
     </div>
     <div class="card">
-      <img src="kuvat/ulko-icon.png" alt="Ulkopuolinen työ">
+      <img src="kuvat/ulko-icon.png" alt="Kuvake ikkunoiden sisä- ja ulkopesusta">
       <h3 class="gradient-title">Sisä- ja ulkopesu</h3>
       <p>Kattava pesu sisältä ja ulkoa – myös vaikeapääsyiset pinnat hoituvat.</p>
     </div>
@@ -111,7 +111,7 @@
     <span class="ba-tag after">Jälkeen</span>
 
     <!-- Handle -->
-    <div class="ba-handle" role="slider" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0">
+    <div class="ba-handle" role="slider" aria-label="Ero liukusäädin" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0">
       <div class="ba-line"></div>
       <div class="ba-circle" data-pct="50"></div>
     </div>
@@ -225,22 +225,22 @@
       <p class="tagline">Kirkkaasti paras ikkunanpesu Lapissa</p>
     </div>
     <div class="footer-contact">
-  <h4>Yhteystiedot</h4>
+  <h3>Yhteystiedot</h3>
   <a href="tel:+358401234567">
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#2c7be5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#2c7be5" stroke-width="2" aria-hidden="true" focusable="false" stroke-linecap="round" stroke-linejoin="round">
       <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.18 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.12.81.3 1.6.54 2.35a2 2 0 0 1-.45 2.11l-1.27 1.27a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.75.24 1.54.42 2.35.54A2 2 0 0 1 22 16.92z"/>
     </svg>
     040 123 4567
   </a>
   <a href="mailto:info@lapinikkuna.fi">
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#4caf50" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#4caf50" stroke-width="2" aria-hidden="true" focusable="false" stroke-linecap="round" stroke-linejoin="round">
       <path d="M4 4h16v16H4z" stroke="none"/>
       <polyline points="4 4 12 13 20 4"/>
     </svg>
     info@lapinikkuna.fi
   </a>
   <p>
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#f5b301" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="#f5b301" stroke-width="2" aria-hidden="true" focusable="false" stroke-linecap="round" stroke-linejoin="round">
       <path d="M21 10c0 6-9 12-9 12S3 16 3 10a9 9 0 1 1 18 0z"/>
       <circle cx="12" cy="10" r="3"/>
     </svg>
@@ -249,7 +249,7 @@
 </div>
 
      <div class="footer-links">
-      <h4>Linkit</h4>
+      <h3>Linkit</h3>
       <a href="#palvelut">Palvelut</a>
       <a href="#prosessi">Prosessi</a>
       <a href="#miksi-me">Miksi me?</a>

--- a/script.js
+++ b/script.js
@@ -98,7 +98,9 @@ if (baWrapper && baAfter && baHandle && knob) {
     baHandle.style.left = pct + '%';
     baGlow.style.setProperty('--x', pct + '%');
     knob.setAttribute('data-pct', Math.round(pct));
-    baHandle.setAttribute('aria-valuenow', Math.round(pct));
+    const value = Math.round(pct);
+    baHandle.setAttribute('aria-valuenow', value);
+    baHandle.setAttribute('aria-valuetext', value + '%');
   };
 
   const moveHandle = (clientX) => {
@@ -119,9 +121,11 @@ if (baWrapper && baAfter && baHandle && knob) {
   // Keyboard
   baHandle.addEventListener('keydown', (e) => {
     const current = parseFloat(baAfter.style.width) || 50;
-    if (e.key === 'ArrowLeft')  setPos(current - 2);
-    if (e.key === 'ArrowRight') setPos(current + 2);
-    if (e.key === 'Enter' || e.key === ' ') setPos(50);
+    if (e.key === 'ArrowLeft') { e.preventDefault(); setPos(current - 2); }
+    if (e.key === 'ArrowRight') { e.preventDefault(); setPos(current + 2); }
+    if (e.key === 'Home') { e.preventDefault(); setPos(0); }
+    if (e.key === 'End') { e.preventDefault(); setPos(100); }
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setPos(50); }
   });
 
   // Init
@@ -264,5 +268,14 @@ if (burger && mobileMenu) {
       burger.setAttribute('aria-expanded', 'false');
       burger.classList.remove('open');
     });
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !mobileMenu.hasAttribute('hidden')) {
+      mobileMenu.setAttribute('hidden', '');
+      burger.setAttribute('aria-expanded', 'false');
+      burger.classList.remove('open');
+      burger.focus();
+    }
   });
 }

--- a/style-fixed-purge.css
+++ b/style-fixed-purge.css
@@ -22,6 +22,13 @@ img {
   display: block;
 }
 
+a:focus-visible,
+button:focus-visible,
+.ba-handle:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Yhteinen ambient-kerros */
 body::before,
 body::after {


### PR DESCRIPTION
## Summary
- add descriptive alt text and ARIA labels for images and mobile navigation
- fix heading hierarchy and hide decorative icons from assistive tech
- show clear keyboard focus and enhance slider and menu keyboard support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898894cfb7883228b646fd89637c4be