### PR TITLE
fix: reliably open quote modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <h1>Ikkunat kirkkaasti helposti <br> ja nopeasti</h1>
       <p>Luotettavaa ikkunanpesua koteihin ja yrityksille</p>
       <div class="buttons">
-        <a href="#" class="cta">Pyydä tarjous</a>
+        <a href="#yhteys" class="cta" data-open="quote-modal">Pyydä tarjous</a>
         <a href="#" class="cta-2">Katso palvelut</a>
       </div>
     </div>
@@ -208,7 +208,7 @@
     </ul>
 
     <div class="cta-actions">
-      <a href="#yhteys" class="cta cta-big">Pyydä tarjous</a>
+      <a href="#yhteys" class="cta cta-big" data-open="quote-modal">Pyydä tarjous</a>
       <a href="#palvelut" class="cta-2 cta-big">Katso palvelut</a>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -280,7 +280,8 @@ if (burger && mobileMenu) {
   });
 }
 // --- Quote Modal ---
-(() => {
+// Modal markup appears after the script tag, so initialize once the DOM is ready.
+document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('quote-modal');
   if (!modal) return;
 
@@ -291,11 +292,14 @@ if (burger && mobileMenu) {
   const firstInput = form?.querySelector('input, textarea, select');
   let lastFocused = null;
 
-  // Etsi kaikki "Pyydä" -CTA:t (hero + CTA-osio)
-  function findOpeners() {
-    const ctas = Array.from(document.querySelectorAll('a.cta, button.cta'));
-    return ctas.filter(el => (el.textContent || '').toLowerCase().includes('pyydä'));
-  }
+  // Avaa modaali kaikille elementeille, joilla on data-open="quote-modal".
+  // Delegoitu kuuntelija varmistaa toiminnan myös dynaamisesti lisätyille napeille.
+  document.addEventListener('click', (e) => {
+    const opener = e.target.closest('[data-open="quote-modal"]');
+    if (!opener) return;
+    e.preventDefault();
+    openModal(opener);
+  });
 
   function openModal(triggerEl) {
     lastFocused = triggerEl || document.activeElement;
@@ -331,14 +335,6 @@ if (burger && mobileMenu) {
       else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
     }
   }
-
-  // Kytke avaajat
-  findOpeners().forEach(opener => {
-    opener.addEventListener('click', (e) => {
-      e.preventDefault();
-      openModal(opener);
-    });
-  });
 
   // Sulje overlay/painikkeet
   overlay?.addEventListener('click', closeModal);
@@ -385,4 +381,4 @@ if (burger && mobileMenu) {
       // Halutessasi: näytä toast tai pieni vahvistusbadge CTA:n lähellä
     }, 700);
   });
-})();
+});


### PR DESCRIPTION
## Summary
- use `data-open="quote-modal"` to mark modal triggers
- delegate click handling to open quote modal regardless of dynamic elements
- initialize quote modal after DOM ready to ensure handlers attach

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a6d58cd08322a45e396c99f0fbcb