### PR TITLE
Fix mobile hero heading size and hide menu on modal open

### DIFF
--- a/script.js
+++ b/script.js
@@ -303,6 +303,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function openModal(triggerEl) {
     lastFocused = triggerEl || document.activeElement;
+    if (burger && mobileMenu && !mobileMenu.hasAttribute('hidden')) {
+      mobileMenu.setAttribute('hidden', '');
+      burger.setAttribute('aria-expanded', 'false');
+      burger.classList.remove('open');
+    }
     modal.classList.add('open');
     modal.setAttribute('aria-hidden', 'false');
     document.body.classList.add('no-scroll');

--- a/style-fixed-purge.css
+++ b/style-fixed-purge.css
@@ -1309,8 +1309,8 @@ a.cta-2.cta-big {
 
   /* Otsikko skaalautuu pienemmäksi mobiilissa */
   .hero .container h1 {
-    font-size: clamp(1.9rem, 6vw, 2.3rem);
-    line-height: 1.15;
+    font-size: var(--font-size-h1);
+    line-height: var(--line-height-h1);
     padding-bottom: 12px;
   }
 


### PR DESCRIPTION
## Summary
- Match mobile hero heading size to standard `h1`
- Close mobile menu automatically when opening the quote modal

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/lapinikkuna/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6898ad4736888322b766a638fdc59705