### PR TITLE
Style mobile menu with theme colors

### DIFF
--- a/style-fixed-purge.css
+++ b/style-fixed-purge.css
@@ -1495,7 +1495,7 @@ a.cta-2.cta-big {
   width: 100%;
   background: var(--color-primary);
   border-radius: 2px;
-  transition: 0.3s;
+  transition: transform 0.3s, opacity 0.3s, background 0.3s;
 }
 .th-burger.open {
   background: rgba(44,123,229,0.12); /* subtle blue background */
@@ -1504,6 +1504,15 @@ a.cta-2.cta-big {
 }
 .th-burger.open span {
   background: var(--color-primary);
+}
+.th-burger.open span:nth-child(1) {
+  transform: translateY(9px) rotate(45deg);
+}
+.th-burger.open span:nth-child(2) {
+  opacity: 0;
+}
+.th-burger.open span:nth-child(3) {
+  transform: translateY(-9px) rotate(-45deg);
 }
 
 /* Mobile menu */
@@ -1514,11 +1523,13 @@ a.cta-2.cta-big {
   align-items: center;
   position: fixed;
   inset: 0;
-  background: rgba(255,255,255,0.98);
+  background: linear-gradient(135deg, rgba(var(--primary-rgb),0.94), rgba(var(--accent-rgb),0.94));
+  color: var(--color-white);
   backdrop-filter: blur(12px);
   z-index: 3000;
-  transition: opacity 0.3s;
+  transition: opacity 0.3s, transform 0.3s;
   opacity: 1;
+  animation: mobileMenuIn 0.3s ease;
 }
 .th-mobile-menu[hidden] {
   display: none !important;
@@ -1534,15 +1545,27 @@ a.cta-2.cta-big {
 }
 .th-mobile-menu a {
   font-size: 1.4rem;
-  color: var(--color-primary);
+  color: var(--color-white);
   text-decoration: none;
   font-weight: 600;
   padding: 12px 32px;
   border-radius: 8px;
-  transition: background 0.2s;
+  transition: background 0.2s, color 0.2s;
 }
 .th-mobile-menu a:hover {
-  background: rgba(44,123,229,0.08);
+  background: rgba(255,255,255,0.15);
+  color: var(--color-white);
+}
+
+@keyframes mobileMenuIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Show burger only on mobile */


### PR DESCRIPTION
## Summary
- add animated burger transformation for mobile menu toggle
- restyle mobile menu with gradient using site theme and polished link hover

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898af7ac47c8322bce1a3bd32f485cd