### PR TITLE
Fix modal email validation and enable Netlify submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,8 @@
         <p class="th-modal__lead">Täytä kentät – palaamme yleensä saman päivän aikana.</p>
       </div>
 
-      <form class="th-modal__form" id="quote-form" novalidate>
+      <form class="th-modal__form" id="quote-form" name="quote" method="POST" data-netlify="true" netlify novalidate>
+        <input type="hidden" name="form-name" value="quote">
         <div class="th-field two-col">
           <div class="th-input">
             <label for="q-name">Nimi</label>
@@ -344,7 +345,7 @@
         </div>
 
         <label class="th-check">
-          <input type="checkbox" id="q-consent" required>
+          <input type="checkbox" id="q-consent" name="consent" required>
           <span>Hyväksyn, että tietoni käsitellään yhteydenottoa varten.</span>
         </label>
 

--- a/script.js
+++ b/script.js
@@ -372,7 +372,7 @@ if (burger && mobileMenu) {
     }
 
     if (!name.value.trim()) setError(name, 'Nimi vaaditaan'); else clearError(name);
-    const emailOk = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(email.value);
+    const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value);
     if (!emailOk) setError(email, 'Syötä validi sähköposti'); else clearError(email);
     if (!consent.checked) { valid = false; consent.focus(); }
 
@@ -382,7 +382,13 @@ if (burger && mobileMenu) {
       submitBtn.disabled = true;
       submitBtn.textContent = 'Lähetetään…';
 
-      setTimeout(() => {
+      const formData = new FormData(form);
+
+      fetch('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(formData).toString()
+      }).then(() => {
         submitBtn.disabled = false;
         submitBtn.textContent = 'Lähetä pyyntö';
         form.reset();
@@ -391,7 +397,10 @@ if (burger && mobileMenu) {
         setTimeout(() => {
           closeModal();
         }, 2000);
-        // Halutessasi: näytä toast tai pieni vahvistusbadge CTA:n lähellä
-      }, 700);
+      }).catch(() => {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Lähetä pyyntö';
+        alert('Lähetys epäonnistui. Yritä myöhemmin uudelleen.');
+      });
     });
 });


### PR DESCRIPTION
## Summary
- Correct email regex to allow valid addresses
- Configure modal form for Netlify and submit via fetch with thanks message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b1708c848322aa0636935f4b0959