### PR TITLE
Ensure Netlify registers contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,5 +360,21 @@
     </div>
   </div>
 
+  <!-- Hidden form for Netlify build bots to register fields -->
+  <form name="quote" method="POST" data-netlify="true" netlify hidden>
+    <input type="hidden" name="form-name" value="quote">
+    <input type="text" name="name">
+    <input type="email" name="email">
+    <input type="tel" name="phone">
+    <select name="service">
+      <option value="Koti">Koti – ikkunanpesu</option>
+      <option value="Yritys">Yritys – toimitilat</option>
+      <option value="Sisä-ulkopesu">Sisä- ja ulkopesu</option>
+      <option value="Muu">Muu / en tiedä</option>
+    </select>
+    <textarea name="message"></textarea>
+    <input type="checkbox" name="consent">
+  </form>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hidden fallback form so Netlify build bots detect the `quote` form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5b794cc8322a8fd9d5237ce7954