### PR TITLE
Ensure Netlify registers contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,8 +308,9 @@
         <p class="th-modal__lead">Täytä kentät – palaamme yleensä saman päivän aikana.</p>
       </div>
 
-      <form class="th-modal__form" id="quote-form" name="quote" method="POST" data-netlify="true" netlify novalidate>
+      <form class="th-modal__form" id="quote-form" name="quote" method="POST" netlify netlify-honeypot="bot-field" novalidate>
         <input type="hidden" name="form-name" value="quote">
+        <input type="text" name="bot-field" hidden>
         <div class="th-field two-col">
           <div class="th-input">
             <label for="q-name">Nimi</label>
@@ -359,6 +360,23 @@
       <p class="th-modal__thanks" role="status" hidden>Kiitos viestistäsi! Otamme pian yhteyttä.</p>
     </div>
   </div>
+
+  <!-- Hidden form for Netlify build bots to register fields -->
+  <form name="quote" method="POST" netlify netlify-honeypot="bot-field" hidden>
+    <input type="hidden" name="form-name" value="quote">
+    <input type="text" name="bot-field">
+    <input type="text" name="name">
+    <input type="email" name="email">
+    <input type="tel" name="phone">
+    <select name="service">
+      <option value="Koti">Koti – ikkunanpesu</option>
+      <option value="Yritys">Yritys – toimitilat</option>
+      <option value="Sisä-ulkopesu">Sisä- ja ulkopesu</option>
+      <option value="Muu">Muu / en tiedä</option>
+    </select>
+    <textarea name="message"></textarea>
+    <input type="checkbox" name="consent">
+  </form>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust modal form to use Netlify honeypot and boolean attribute
- mirror honeypot field in hidden fallback form so build bots detect all fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5b794cc8322a8fd9d5237ce7954