### PR TITLE
Fix mobile menu toggle and modal spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,13 +65,10 @@
 
 <body>
 <script>document.documentElement.classList.remove('no-js');</script>
-<button class="th-burger" aria-label="Avaa valikko">
-  <svg class="i i-24" aria-hidden="true"><use href="#i-menu"/></svg>
-</button>
-
-<span></span>
-<span></span>
-<span></span>
+<button class="th-burger" aria-label="Avaa valikko" aria-expanded="false" type="button">
+  <span></span>
+  <span></span>
+  <span></span>
 </button>
 <header class="th-header">
 <div class="th-header__inner">

--- a/style.merged.css
+++ b/style.merged.css
@@ -1575,6 +1575,8 @@ body.no-scroll { overflow: hidden; }
   border-radius: 22px;
   box-shadow: 0 40px 80px rgba(0,0,0,0.18), inset 0 1px rgba(255,255,255,0.6);
   padding: clamp(22px, 4vw, 36px);
+  /* Extra bottom padding to stay above mobile browser bars */
+  padding-bottom: calc(clamp(22px, 4vw, 36px) + env(safe-area-inset-bottom));
   transform-origin: 50% 44%;
   opacity: 0; animation: modalIn 260ms cubic-bezier(.16,.84,.44,1) forwards 60ms;
 }


### PR DESCRIPTION
## Summary
- Fix burger button markup so mobile navigation icon appears and toggles correctly
- Add safe-area bottom padding to modal dialog so send button stays visible on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c3a4427e4832280f2ad3434e3aff9